### PR TITLE
Change operation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Here's an example of a Transaction Object:
          },
          "coin_change":{
             "coin_identifier":{
-               "identifier":"fc11e18ab005fe3b1d5ba92dca77a289fe497b3ee41b843526589ec4d5cb9edd0"
+               "identifier":"fc11e18ab005fe3b1d5ba92dca77a289fe497b3ee41b843526589ec4d5cb9edd0000"
             },
             "coin_action":"UTXO_CONSUMED"
          }
@@ -131,7 +131,7 @@ Here's an example of a Transaction Object:
          },
          "coin_change":{
             "coin_identifier":{
-               "identifier":"fc11e18ab005fe3b1d5ba92dca77a289fe497b3ee41b843526589ec4d5cb9edd1"
+               "identifier":"fc11e18ab005fe3b1d5ba92dca77a289fe497b3ee41b843526589ec4d5cb9edd0100"
             },
             "coin_action":"UTXO_CREATED"
          }


### PR DESCRIPTION
This PR introduces following changes:

Change 1:
A transaction contains inputs and outputs. As in the official Rosetta-Bitcoin implementation this should be reflected https://github.com/coinbase/rosetta-bitcoin/blob/f4fe50f3c654b664abef6d869373a18f2e099d13/bitcoin/types.go#L47
Therefore, instead of having only the operation type `UTXO`, this PR will introduce the types `UTXO_INPUT` and `UTXO_OUTPUT`.
It's implemented similarly here: https://community.rosetta-api.org/t/implementing-the-construction-api-for-utxo-model-coins/100/5

Change 2:
The official Rosetta-Bitcoin implementation does make use of the status `SUCCESS` and `SKIPPED`.
All on-chain transactions (that are included in the ledger) do get the operation status `SUCCESS`. https://github.com/coinbase/rosetta-bitcoin/blob/f4fe50f3c654b664abef6d869373a18f2e099d13/bitcoin/types.go#L57 
In our case it's similar. All outputs that are returned by the `utxo-changes` endpoint did actually change the ledger state.
Therefore, we should use the `SUCCESS` status too. Another example is here: https://github.com/tronprotocol/tron-rosetta-api#sample-request-12
In addition, since we have atomic transactions, we need to use the same status code for all operations within a transaction anyways (see https://www.rosetta-api.org/docs/models/Operation.html#properties). Therefore using only `SUCCESS` should be fine.
**Note:** Transactions that get constructed by the Construction API, don't populate the status field.

Change 3:
The coin `identifier` in `coin_identifier` identifies the output. In Bitcoin, this identifier would be transaction_hash:index.
In IOTA we can do the same and use the output id (`output id = transaction id + output index`).
e.g `fc11e18ab005fe3b1d5ba92dca77a289fe497b3ee41b843526589ec4d5cb9edd0` instead of `fc11e18ab005fe3b1d5ba92dca77a289fe497b3ee41b843526589ec4d5cb9edd0000`

Change 4:
Per default, the output of a transaction should get `"coin_action":"UTXO_CREATED"` instead of `"coin_action":"UTXO_CONSUMED"`.
The example should reflect the default case.

